### PR TITLE
Use build_id instead of app_id for application URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ WORKDIR /usr/src/app
 # Copy application source
 COPY . .
 
-# This command we will use as marker from where we can show logs to the customer
-RUN echo "START-LOGGING"
 RUN npm install && \
     npm run build
 

--- a/src/routes/show.svelte
+++ b/src/routes/show.svelte
@@ -41,7 +41,7 @@
 			runmeService().build(buildId)
 				.then(([response]) => {
 					build.set(response)
-					loadUrl(`https://${response.app_id}.runme.io`)
+					loadUrl(`https://${response.id}.runme.io`)
 				})
 				.catch(() => {
 					let appendError = `<br>Please go to the <a href="/">generator</a> page and create a button and run url.`


### PR DESCRIPTION
I implemented cache for builds and now we can run several builds for one application so we will use build ID for public URLs instead of application ID.