### PR TITLE
fix(show): APP_HOSTING cannot have empty variable only with space

### DIFF
--- a/src/routes/show.svelte
+++ b/src/routes/show.svelte
@@ -83,8 +83,8 @@
                     : null,
             }
             const queryString = toQueryString(queryParam)
-
             const deploymentUrl = DEPLOYMENT.host.trim()
+
             if (deploymentUrl) {
                 header.setDeploymentUrl(`https://${deploymentUrl}/runme?${queryString}`)
             }


### PR DESCRIPTION
APP hosting cannot have empty env_vars, but instead a space.

![Screenshot 2020-04-21 at 10 53 06](https://user-images.githubusercontent.com/633730/79848646-a649c280-83c1-11ea-9e51-049c289bcf49.png)

This PR will trim the env_var to consist with the empty field so we can manage the show of the deployment button with the env var without add any extra logic to it.