### PR TITLE
fix(env): detect boolean from env-vars

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -1,3 +1,5 @@
+const detectBool = (value) => value === 'true' || value === 'false' ? JSON.parse(value) : value
+
 export const JEXIA_CREDENTIALS = {
   applicationProjectID: 'jexia-application-project-id',
   key: 'jexia-api-key',
@@ -6,7 +8,7 @@ export const JEXIA_CREDENTIALS = {
 
 export const RUNME_API = {
   host: 'runme-api-host',
-  secure: 'runme-api-secure',
+  secure: detectBool('runme-api-secure'),
 }
 
 export const DEPLOYMENT = {


### PR DESCRIPTION
This PR will handle the check on `boolean` for the env-vars given from the docker container or .env file.

Default all env-vars values are `strings`